### PR TITLE
docs: fix .env path and add android build folder to gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,14 @@ pnpm install
 
 3. Create .env file
 
-Using the .env.template file as a template, create a .env file in the root of the project.
+Using the .env.template file as a template, create a .env file in the `apps/expo-app` directory
 
+First:
+```bash
+cd apps/expo-app
+```
+
+Second:
 ```bash
 cp .env.template .env
 ```

--- a/apps/expo-app/.gitignore
+++ b/apps/expo-app/.gitignore
@@ -20,3 +20,4 @@ expo-env.d.ts
 # @end expo-cli
 
 ios
+android


### PR DESCRIPTION
1) The default readme forgets to add a `cd` argument to go to where the `.env.template` is.

2) It also forgets to include the android folder in .gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to clarify where to create the `.env` file and added steps for changing directories.
* **Chores**
  * Updated ignore rules to exclude the `android` directory from version control in the mobile app project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->